### PR TITLE
Use GET instead of HEAD to return headers

### DIFF
--- a/getm/http.py
+++ b/getm/http.py
@@ -32,13 +32,12 @@ class Session(requests.Session):
 
     @lru_cache(maxsize=20)
     def head(self, url: str):
-        resp = super().head(url)
-        if codes.forbidden == resp.status_code:
-            # S3 signed urls return 403 for HEAD, possibly depending on signer.
-            resp = self.get(url, stream=True)
-            resp.raise_for_status()
-        else:
-            resp.raise_for_status()
+        """
+        Return the headers from a GET request.
+        """
+        # HEAD on S3 signed urls does no include "Content-Length", so we use GET instead
+        resp = self.get(url, stream=True)
+        resp.raise_for_status()
         return resp.headers
 
     def size(self, url: str) -> int:

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -39,6 +39,9 @@ class HeadHandler(SilentHandler):
                 self.send_header(k, v)
         self.end_headers()
 
+    def do_GET(self, *args, **kwargs):
+        self.do_HEAD(*args, **kwargs)
+
 class TestHTTP(unittest.TestCase):
     def setUp(self):
         suppress_warnings()


### PR DESCRIPTION
This is primarily motivated by S3 signed URLs not returning the
Content-Length header for HEAD requests.