### PR TITLE
Constrain shared memory and concurrent downloads

### DIFF
--- a/getm/cli.py
+++ b/getm/cli.py
@@ -170,7 +170,7 @@ def parse_args(cli_args: Optional[List[str]]=None) -> argparse.Namespace:
                         help="Number of concurrent single part downloads")
     parser.add_argument("--multipart-concurrency",
                         default=2,
-                        help="Number of concurrent multipart downloads")
+                        help="Number of concurrent multipart downloads. Can either be '1' or '2'")
     parser.add_argument("--multipart-threshold",
                         default=default_chunk_size,
                         help="multipart threshold")
@@ -179,6 +179,9 @@ def parse_args(cli_args: Optional[List[str]]=None) -> argparse.Namespace:
         parser.print_usage()
         print()
         print("One of 'url' or '--manifest' must be specified, but not both.")
+        sys.exit(1)
+    if not (1 <= args.multipart_concurrency <= 2):
+        parser.print_usage()
         sys.exit(1)
     return args
 

--- a/getm/reader.py
+++ b/getm/reader.py
@@ -136,7 +136,7 @@ class URLReaderKeepAlive(BaseURLReader, Process):
         self.chunk_size = chunk_size
         self.size = http.size(url)
         self._start = self._stop = 0
-        self.max_read = 40 * self.chunk_size
+        self.max_read = 10 * self.chunk_size
         self._buf = SharedCircularBuffer(size=chunk_size + self.max_read, create=True)
         super().__init__()
 


### PR DESCRIPTION
- Use 10 MB of shared memory for each multipart download.
- Constrain number of concurrent multipart downloads to 1 <= # <= 2