### PR TITLE
Include response in http.accessable

### DIFF
--- a/getm/http.py
+++ b/getm/http.py
@@ -41,12 +41,16 @@ class Session(requests.Session):
             return resp.headers
 
     def accessable(self, url: str) -> Tuple[bool, Optional[requests.Response]]:
+        """Probe 'url' for a normal response. Upon error, grab the full reponse. In the case of S3 and GS signed URLs,
+        the full response contains extra error information such as expiration.
+        """
         try:
             self.head(url)
             return (True, None)
         except HTTPError as e:
+            resp = self.get(url)
             if e.response.status_code in (400, 403, 404):
-                return (False, e.response)
+                return (False, resp)
             else:
                 raise
 

--- a/getm/http.py
+++ b/getm/http.py
@@ -2,7 +2,7 @@ import requests
 import warnings
 from functools import lru_cache
 from urllib.parse import urlparse
-from typing import Generator
+from typing import Generator, Optional, Tuple
 
 from requests import codes
 from requests.exceptions import HTTPError
@@ -40,13 +40,13 @@ class Session(requests.Session):
             resp.raise_for_status()
             return resp.headers
 
-    def accessable(self, url: str) -> bool:
+    def accessable(self, url: str) -> Tuple[bool, Optional[requests.Response]]:
         try:
             self.head(url)
-            return True
+            return (True, None)
         except HTTPError as e:
             if e.response.status_code in (400, 403, 404):
-                return False
+                return (False, e.response)
             else:
                 raise
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -70,7 +70,10 @@ class TestHTTP(unittest.TestCase):
             with http_session() as http:
                 for expected, Handler.status in tests:
                     with self.subTest(expected=expected, status=Handler.status):
-                        self.assertEqual(expected, http.accessable(f"{host}/{uuid4()}"))
+                        accessable, resp = http.accessable(f"{host}/{uuid4()}")
+                        self.assertEqual(expected, accessable)
+                        if resp:
+                            self.assertEqual(Handler.status, resp.status_code)
 
             with self.subTest("should raise"):
                 Handler.status = 500


### PR DESCRIPTION
If http.accessable returns Flase, include response. Otherwise
response is None.