### PR TITLE
Document the Python 3.7 backport of sharedmemory

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ sudo dev_scripts/resize_shm.sh 64M
 sudo dev_scripts/resize_shm.sh 8G
 ```
 
+## [sharedmemory](https://docs.python.org/3/library/multiprocessing.shared_memory.html) backport to Python 3.7
+
+getm relies on the `sharedmemory` module, which was introduced in Python 3.8. Since a large portion of getm's audience
+relies on Python 3.7, a C extension
+[backport](https://github.com/xbrianh/getm/tree/master/getm/concurrent/shared_memory_37) of `sharedmemory` is included.
+
+The backport adds significant complexity getm's code base, requiring C/C++ knowlege to maintain, as well as knowledge of
+[CPython](https://github.com/python/cpython). It will be removed when enough getm users have migrated to Python 3.8 or
+greater.
+
 ## Links
 Project home page [GitHub](https://github.com/xbrianh/getm)  
 Package distribution [PyPI](https://pypi.org/project/getm/)


### PR DESCRIPTION
closes #30